### PR TITLE
Update to allow use of AWS Profile

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,8 @@ Configure settings:
 
 .. code-block:: python
 
+    # OPTIONALLY SET EASYEDDIE_USE_AWS_PROFILE = True to use local profile and not have to set the next three vars.
+
     AWS_DEFAULT_REGION = 'eu-west-1'
     AWS_ACCESS_KEY_ID = 'foo'
     AWS_SECRET_ACCESS_KEY = 'bar'

--- a/easy_eddie/settings.py
+++ b/easy_eddie/settings.py
@@ -1,16 +1,18 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
-AWS_DEFAULT_REGION = getattr(settings, 'EASYEDDIE_AWS_DEFAULT_REGION', getattr(settings, 'AWS_DEFAULT_REGION'))
-if not AWS_DEFAULT_REGION:
+USE_AWS_PROFILE = getattr(settings, 'EASYEDDIE_USE_AWS_PROFILE', False)
+
+AWS_DEFAULT_REGION = getattr(settings, 'EASYEDDIE_AWS_DEFAULT_REGION', getattr(settings, 'AWS_DEFAULT_REGION', None))
+if not AWS_DEFAULT_REGION and not USE_AWS_PROFILE:
     raise ImproperlyConfigured('Set AWS_DEFAULT_REGION or EASYEDDIE_AWS_DEFAULT_REGION in your settings.')
 
-AWS_ACCESS_KEY_ID = getattr(settings, 'EASYEDDIE_AWS_ACCESS_KEY_ID', getattr(settings, 'AWS_ACCESS_KEY_ID'))
-if not AWS_ACCESS_KEY_ID:
+AWS_ACCESS_KEY_ID = getattr(settings, 'EASYEDDIE_AWS_ACCESS_KEY_ID', getattr(settings, 'AWS_ACCESS_KEY_ID', None))
+if not AWS_ACCESS_KEY_ID and not USE_AWS_PROFILE:
     raise ImproperlyConfigured('Set AWS_ACCESS_KEY_ID or EASYEDDIE_AWS_ACCESS_KEY_ID in your settings.')
 
-AWS_SECRET_ACCESS_KEY = getattr(settings, 'EASYEDDIE_AWS_SECRET_ACCESS_KEY', getattr(settings, 'AWS_SECRET_ACCESS_KEY'))
-if not AWS_SECRET_ACCESS_KEY:
+AWS_SECRET_ACCESS_KEY = getattr(settings, 'EASYEDDIE_AWS_SECRET_ACCESS_KEY', getattr(settings, 'AWS_SECRET_ACCESS_KEY', None))
+if not AWS_SECRET_ACCESS_KEY and not USE_AWS_PROFILE:
     raise ImproperlyConfigured('Set AWS_SECRET_ACCESS_KEY or EASYEDDIE_AWS_SECRET_ACCESS_KEY in your settings.')
 
 CLOUD_WATCH_LOG_GROUP_NAMES = getattr(settings, 'EASYEDDIE_CLOUD_WATCH_LOG_GROUP_NAMES')


### PR DESCRIPTION
USE_AWS_PROFILE can now be set to True to skip the validation checks and use a local profile.